### PR TITLE
Tweaking Watchable Performance Events

### DIFF
--- a/external/mor1kx/rtl/verilog/mor1kx_ctrl_cappuccino.v
+++ b/external/mor1kx/rtl/verilog/mor1kx_ctrl_cappuccino.v
@@ -1149,10 +1149,10 @@ module mor1kx_ctrl_cappuccino
             .spr_sys_mode_i     (spr_sr[`OR1K_SPR_SR_SM]),
 
             // Used Events (working)
-            .pcu_event_load_i         ((execute_op_lsu_load_i & padv_execute_o) | (execute_op_lsu_store_i & padv_execute_o)), // D-Cache Access (Custom)
+            .pcu_event_load_i         ((execute_op_lsu_load_i & padv_execute_o) | (execute_op_lsu_store_i & padv_execute_o)), // LSU Hit (Custom)
             .pcu_event_store_i        (branch_mispredict_i & padv_decode_o),                                                  // Branch Stall (Custom)
             .pcu_event_ifetch_i       (icache_hit_i),                                                                         // I-Cache Hit (Custom)
-            .pcu_event_dcache_miss_i  (dchache_miss),                                                                         // D-Cache Miss
+            .pcu_event_datadep_stall_i (execute_waiting),                                                                     // Register Dependency Stall (Custom)
             .pcu_event_icache_miss_i  (!icache_hit_i & !waiting_for_fetch),                                                   // I-Cache Miss
             .pcu_event_ifetch_stall_i (!padv_fetch_o),                                                                        // I-Fetch Stall
             .pcu_event_lsu_stall_i    (!ctrl_valid_i),                                                                        // LSU Stall
@@ -1161,7 +1161,7 @@ module mor1kx_ctrl_cappuccino
             .pcu_event_brn_stall_i     (branch_mispredict_i & padv_decode_o),                                                 // Branch Stall
             .pcu_event_dtlb_miss_i     (except_dtlb_miss_i),                                                                  // D-TLB Miss
             .pcu_event_itlb_miss_i     (except_itlb_miss_i),                                                                  // I-TLB Miss
-            .pcu_event_datadep_stall_i (execute_waiting)                                                                      // Register Dependency Stall
+             .pcu_event_dcache_miss_i  (dchache_miss)                                                                         // D-Cache Miss
             );
       end
       else begin


### PR DESCRIPTION
# Description

In this commit, I tweak the performance event unit. Since we are not aiming for data cache, I have replaced the data cache miss event by the register file stall one.